### PR TITLE
Update package.json for fork

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "honeycomb-beeline",
-  "description": "automatic instrumentation for honeycomb.io",
+  "name": "@outreach/honeycomb-beeline",
+  "description": "automatic instrumentation for honeycomb.io (Outreach fork)",
   "author": "support@honeycomb.io",
   "volta": {
     "node": "12.22.1"
@@ -9,7 +9,7 @@
   "version": "2.8.1",
   "repository": {
     "type": "git",
-    "url": "https://github.com/honeycombio/beeline-nodejs.git"
+    "url": "https://github.com/getoutreach/beeline-nodejs.git"
   },
   "engines": {
     "node": ">= 10.*"


### PR DESCRIPTION
This commit sets up a private fork of beeline-nodejs.

Note that this GitHub repo is public, so we should avoid internal-only
referances in code and PR discussions.

The intent here is not to hide what we're doing or keep this work to
ourselves.  We're forking because the upstream library is in maintenance
mode, but we'd like to add features to it, and we're not ready to
migrate to the new and improved OpenTelemtry equivalents just yet.