### PR TITLE
Add trace-level rollup support (outreach fork)

### DIFF
--- a/lib/api/index.js
+++ b/lib/api/index.js
@@ -214,6 +214,10 @@ module.exports = {
     },
   },
 
+  incrementTraceRollup(key, durationMs, count) {
+    return apiImpl.incrementTraceRollup(key, durationMs, count);
+  },
+
   addTraceContext(map) {
     return apiImpl.addTraceContext(mapFieldsToApp(map));
   },

--- a/lib/api/libhoney.js
+++ b/lib/api/libhoney.js
@@ -109,6 +109,7 @@ module.exports = class LibhoneyEventAPI {
     tracker.setTracked({
       id,
       traceContext: propagatedContext,
+      rollupContext: {},
       stack: [],
       dataset: dataset || this.defaultDataset,
     });
@@ -116,6 +117,16 @@ module.exports = class LibhoneyEventAPI {
   }
 
   finishTrace(span) {
+    const context = tracker.getTracked();
+    if (context) {
+      // `context` should always be set by this point.  But we use an `if` guard
+      // anyway, so we can hit the standard error-handling in `finishSpan`
+      // rather than doing some sort of invalid dereference here.
+
+      const rollups = context.rollupContext;
+      span.addContext(rollups);
+    }
+
     this.finishSpan(span);
     tracker.deleteTracked();
   }
@@ -189,6 +200,7 @@ module.exports = class LibhoneyEventAPI {
       id: parentContext.id,
       parentId: parentId,
       traceContext: parentContext.traceContext,
+      rollupContext: parentContext.rollupContext,
       dataset: parentContext.dataset,
       stack: [span],
     };
@@ -324,6 +336,34 @@ module.exports = class LibhoneyEventAPI {
       return;
     }
     delete context.traceContext[key];
+  }
+
+  // Unofficial support for rollups, added in a fork of this library.
+  //
+  // Although the upstream beeline does provide support for rollups, they don't
+  // work with async spans, which are used heavily in many instrumentations,
+  // including our own.
+  //
+  // This trace-level rollup tracking should work better in the presence of
+  // async spans, though it will of course be unable to report accurately if the
+  // rollups are incremented after the trace is already finished.
+  //
+  // - `key` is the name of the rollup being added to.
+  // - `durationMs` is the duration being added to the rollup.
+  // - `count` is the counter value being added to the rollup.
+  //    It is optional and defaults to 1.
+  incrementTraceRollup(key, durationMs, count = 1) {
+    const context = tracker.getTracked();
+    if (!context) {
+      // valid, since we can end up in our instrumentation outside of requests we're tracking
+      return;
+    }
+
+    let countKey = "rollups." + key + ".count";
+    let durationMsKey = "rollups." + key + ".duration_ms";
+
+    context.rollupContext[countKey] = (context.rollupContext[countKey] || 0) + count;
+    context.rollupContext[durationMsKey] = (context.rollupContext[durationMsKey] || 0) + durationMs;
   }
 
   dumpRequestContext() {

--- a/lib/types.d.ts
+++ b/lib/types.d.ts
@@ -134,6 +134,8 @@ declare namespace beeline {
     /** @deprecated this method will be removed in the next major release. */
     removeContext(key: string): void;
 
+    incrementTraceRollup(key: string, durationMs: number, count?: number): void;
+
     customContext: {
       /** @deprecated this method will be removed in the next major release. Please use .addTraceContext. */
       add(k: string, v: any): void;

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "node": "12.22.1"
   },
   "license": "Apache-2.0",
-  "version": "2.8.1",
+  "version": "2.8.1-outreach1",
   "repository": {
     "type": "git",
     "url": "https://github.com/getoutreach/beeline-nodejs.git"


### PR DESCRIPTION
Updates honeycomb-beeline with a new method, `incrementTraceRollup`,
which can be used to accumulate running counters over the course of a
request, to be reported on the top-level trace span when the request is
finished.

The original, unpatched honeycomb-beeline had some not-well-documented
suport for rollups, but it doesn't work with async spans, and most spans
are async.  This patched version will work with async spans, though it
does assume that even async spans don't outlive their parent trace.
That's generally true for us, but it's also a stronger assumption than
the upstream libraries are willing to make.  Our counts may be lower
than expected if that expectation is violated.