### PR TITLE
Add types for two internal functions

### DIFF
--- a/lib/deterministic_sampler.d.ts
+++ b/lib/deterministic_sampler.d.ts
@@ -1,0 +1,9 @@
+import { SamplerResponse } from "./types";
+
+// Note that this is more specific than upstream `types.d.ts`.  They define the
+// samplerHook function's argument as `event: unknown`.  We're more opinionated.
+interface SamplerFn {
+  (data: {[key: string]: any}): SamplerResponse;
+}
+
+export default function(sampleRate: number) : SamplerFn;

--- a/lib/instrumentation/trace-util.d.ts
+++ b/lib/instrumentation/trace-util.d.ts
@@ -1,0 +1,8 @@
+import { IncomingMessage } from 'http';
+import { TraceContext } from '../types';
+
+// TODO: There are lots more functions exported by this file.  We did not bother
+// to declare types for all of them, but we should, if we decide that we need to
+// `import` them into TypeScript projects.
+
+export function getTraceContext(traceIdSource: any, req: IncomingMessage): TraceContext

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "node": "12.22.1"
   },
   "license": "Apache-2.0",
-  "version": "2.8.1-outreach2",
+  "version": "2.8.1-outreach3",
   "repository": {
     "type": "git",
     "url": "https://github.com/getoutreach/beeline-nodejs.git"


### PR DESCRIPTION
Adds type declarations for `deterministicSampler` and `getTraceContext`
that we intend to import from our TypeScript wrapper libraries.