### PR TITLE
bump to next unpublished version

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "node": "12.22.1"
   },
   "license": "Apache-2.0",
-  "version": "3.4.0-outreach4",
+  "version": "3.4.0-outreach6",
   "repository": {
     "type": "git",
     "url": "https://github.com/getoutreach/beeline-nodejs.git"


### PR DESCRIPTION
When I tried to publish `3.4.0-outreach4`, I got the following response:
```
npm ERR! code E403
npm ERR! 403 403 Forbidden - PUT https://registry.npmjs.org/@outreach%2fhoneycomb-beeline - You cannot publish over the previously published versions: 3.4.0-outreach4.
npm ERR! 403 In most cases, you or one of your dependencies are requesting
npm ERR! 403 a package version that is forbidden by your security policy, or
npm ERR! 403 on a server you do not have access to.
```

I hit the same error for `3.4.0-outreach5` as well, finally succeeded with `3.4.0-outreach6`. 